### PR TITLE
User Created Sandwich Readability & Update Sandwich Before POST 

### DIFF
--- a/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreator.jsx
+++ b/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreator.jsx
@@ -5,10 +5,9 @@ import { renderBreadChoices } from "./SandwichCreatorTabs/BreadCreate.jsx";
 import { renderMeatChoices } from "./SandwichCreatorTabs/MeatCreate.jsx";
 import { renderToppingChoices } from "./SandwichCreatorTabs/ToppingCreate.jsx";
 
-export const SandwichCreator = ({currentSandwich, setCurrentSandwich, setSelectedView}) => {
+export const SandwichCreator = ({currentSandwich, setCurrentSandwich, setSelectedView, breadChoice, setBreadChoice}) => {
     const [currentViewIngredients, setIngredients] = useState([]);
     const [input, setInput] = useState(1);
-    const [breadChoice, setBreadChoice] = useState({});
     const [isVegetarian, setIsVegetarian] = useState(false);
     const [meatChoice, setMeatChoice] = useState([]);
     const [toppingChoice, setToppingChoice] = useState([]);

--- a/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreatorTabs/MeatCreate.jsx
+++ b/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreatorTabs/MeatCreate.jsx
@@ -16,7 +16,14 @@ export const renderMeatChoices = ({ setCurrentSandwich, currentSandwich, current
 
     const handleMeatChange = (event) => {
         const selectedMeat = JSON.parse(event.target.value);
-    
+        
+        if (currentSandwich.sandwichIngredients.some(i => i.id == selectedMeat.id)) {
+            const index = currentSandwich.sandwichIngredients.findIndex(i => i.id == selectedMeat.id);
+            if (index > -1) {
+                currentSandwich.sandwichIngredients.splice(index, 1);
+            }
+        }
+
         if (event.target.checked) {
             setMeatChoice([...meatChoice, selectedMeat]);
         } else {
@@ -60,7 +67,7 @@ export const renderMeatChoices = ({ setCurrentSandwich, currentSandwich, current
                                 type="checkbox"
                                 name="meat"
                                 value={JSON.stringify(i)}
-                                checked={!isVegetarian && meatChoice.some(m => m.id == i.id)}
+                                checked={!isVegetarian && meatChoice.some(m => m.id == i.id) || currentSandwich.sandwichIngredients.some(m => m.id == i.id)}
                                 disabled={isVegetarian}
                                 onChange={handleMeatChange}
                             />

--- a/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreatorTabs/ToppingCreate.jsx
+++ b/client/src/components/sandwich-screen/SandwichCreatorTabs/SandwichCreatorTabs/ToppingCreate.jsx
@@ -10,6 +10,13 @@ export const renderToppingChoices = ({ setCurrentSandwich, currentSandwich, curr
     const handleToppingChange = (event) => {
         const selectedTopping = JSON.parse(event.target.value);
     
+        if (currentSandwich.sandwichIngredients.some(i => i.id == selectedTopping.id)) {
+            const index = currentSandwich.sandwichIngredients.findIndex(i => i.id == selectedTopping.id);
+            if (index > -1) {
+                currentSandwich.sandwichIngredients.splice(index, 1);
+            }
+        }
+
         if (event.target.checked) {
             setToppingChoice([...toppingChoice, selectedTopping]);
         } else {
@@ -18,11 +25,10 @@ export const renderToppingChoices = ({ setCurrentSandwich, currentSandwich, curr
     }
 
     const handleToppingSave = () => {
-        if (toppingChoice.length === 0)
-            {
-                setIsEmpty(true)
-                return;
-            }
+        if (toppingChoice.length === 0) {
+            setIsEmpty(true)
+            return;
+        }
 
         const uniqueToppings = toppingChoice.filter((topping) =>
             !currentSandwich.sandwichIngredients.some(
@@ -53,7 +59,10 @@ export const renderToppingChoices = ({ setCurrentSandwich, currentSandwich, curr
                                 type="checkbox"
                                 name="topping"
                                 value={JSON.stringify(i)}
-                                checked={toppingChoice.some(t => t.id == i.id)}
+                                checked={
+                                    toppingChoice.some((t) => t.id == i.id) ||
+                                    currentSandwich.sandwichIngredients.some((m) => m.id == i.id)
+                                }
                                 onChange={handleToppingChange}
                             />
                             <Label>

--- a/client/src/components/sandwich-screen/SandwichScreen.jsx
+++ b/client/src/components/sandwich-screen/SandwichScreen.jsx
@@ -10,13 +10,14 @@ export const SandwichScreen = ({loggedInUser}) => {
         }
     )
     const [selectedView, setSelectedView] = useState(1)
+    const [breadChoice, setBreadChoice] = useState({});
 
     const renderView = () => {
         switch(selectedView) {
             case 1:
                 return <div>{defaultView()}</div>;
             case 2:
-                return <SandwichCreator currentSandwich={currentSandwich} setCurrentSandwich={setCurrentSandwich} setSelectedView={setSelectedView}/>;
+                return <SandwichCreator currentSandwich={currentSandwich} setCurrentSandwich={setCurrentSandwich} setSelectedView={setSelectedView} breadChoice={breadChoice} setBreadChoice={setBreadChoice}/>;
         }
     }
     
@@ -33,18 +34,38 @@ export const SandwichScreen = ({loggedInUser}) => {
                         </div>
                         :
                         <div>
-                            {/* Implement list of ingredients after finishing create a sandwich view */}
+                            <h3>{currentSandwich.sandwichIngredients.find(si => si.typeId === 1)?.name} Sandwich</h3>
+                            <ul>
+                                {currentSandwich.sandwichIngredients
+                                    .filter(si => si?.typeId !== 1)
+                                    .map((s) => (
+                                        <li key={s.id}>{s.name}</li>
+                                ))}
+                            </ul>
+                            <Button onClick={() => setSelectedView(2)}>
+                                Edit Sandwich
+                            </Button>
+                            <Button onClick={() => setCurrentSandwich({customerId: loggedInUser.id, sandwichIngredients: []}, setBreadChoice({}))}>
+                                Delete Sandwich
+                            </Button>
                         </div>
                     }
                 </div>
                 <div className="my-sandwich-price">
                     Total: $0.00
                 </div>
+                {currentSandwich.sandwichIngredients.length === 0 ?
                 <div className="my-sandwich-create">
                     <Button onClick={() => setSelectedView(2)} className="add-ingredient-btn">
                         Add Ingredients
                     </Button>
                 </div>
+                :
+                <div>
+                    <Button>
+                        Save Sandwich
+                    </Button>
+                </div>}
             </div>
         )
     }


### PR DESCRIPTION
### Success

The purpose of this branch was to finish the functionality of Sandwich Screen, which involves being able to update a sandwich object before making a POST to the API

### Background

Finishing the ability for the user to create a sandwich while insuring full-functionality on the front-end was difficult as filtering was required at several points to delete necessary ingredients or to ensure the same ingredient was not added twice. The price still needs to be calculated.

### Files edited on `ft/my-sandwich-view/ezjbrewer`
- `SandwichCreator.jsx` - Adjusted prop drilling where needed
- `MeatCreate.jsx` and `ToppingCreate,jsx` - Adjusted to allow checkbox values to be checked if that entity already existed in the current sandwich
- `BreadCreate.jsx` - Adjusted to allow checkbox values to be checked if that entity already existed in the current sandwich

### Goal

- To provide visibility of a created or edited sandwich before POSTing to the database